### PR TITLE
Use io.ReadFull, in cases where the PDU does not fit into one read syscall

### DIFF
--- a/bser/decoder.go
+++ b/bser/decoder.go
@@ -36,11 +36,9 @@ func Decode(r io.Reader) (interface{}, error) {
 	}
 
 	buffer := make([]uint8, int(pduSize))
-	received, err = r.Read(buffer)
+	received, err = io.ReadFull(r, buffer)
 	if err != nil {
 		return nil, err
-	} else if received != int(pduSize) {
-		return nil, errors.New("failed to load PDU")
 	}
 
 	val, _, err := decodeInterface(buffer)


### PR DESCRIPTION
This can happen when large numbers of files are reported, for
instance.  Failure to use ReadFull results in a "failed to load PDU"
due to only getting a partial response.

This removes the check en verify the length, as ReadAll guarantees
that it returns an `err` in such cases.