### PR TITLE
Abort in cases where encodeInterface fails

### DIFF
--- a/bser/encoder.go
+++ b/bser/encoder.go
@@ -8,6 +8,9 @@ import (
 func Encode(o interface{}) ([]uint8, error) {
 	buffer := []uint8{0, 1, int64Marker, 0, 0, 0, 0, 0, 0, 0, 0}
 	buffer, err := encodeInterface(o, buffer)
+	if err != nil {
+		return nil, err
+	}
 	pduSize := int64(len(buffer)) - 11 // header
 	*(*int64)(unsafe.Pointer(&buffer[3])) = pduSize
 


### PR DESCRIPTION
This can happen when large numbers of files are reported, for
instance.  Failure to use ReadFull results in a "failed to load PDU"
due to only getting a partial response.

This removes the check en verify the length, as ReadAll guarantees
that it returns an `err` in such cases.