### PR TITLE
Use the getError method to pipe through errors in Command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -33,6 +33,11 @@ func Command(watchmanPath string, cmd interface{}) (interface{}, error) {
 		return nil, err
 	}
 
+	err = getError(val)
+	if err != nil {
+		return nil, err
+	}
+
 	return val, nil
 }
 


### PR DESCRIPTION
The getError helper is only used to extract errors from the
get-sockname call, and not the ultimate command.  Use it to cleanly
return an err in such cases.